### PR TITLE
Fix E

### DIFF
--- a/iSeries/iSeries/Champions/Marksman/Kalista/Kalista.cs
+++ b/iSeries/iSeries/Champions/Marksman/Kalista/Kalista.cs
@@ -712,7 +712,7 @@ namespace iSeries.Champions.Marksman.Kalista
             foreach (var hero in
                 HeroManager.Enemies.Where(
                     x =>
-                    this.spells[SpellSlot.E].IsInRange(x) && this.GetActualHealth(x) < this.GetActualDamage(x)
+                    this.spells[SpellSlot.E].IsInRange(x) && x.Health < this.GetActualDamage(x)
                     && !x.IsDead))
             {
                 if (hero.HasBuffOfType(BuffType.Invulnerability) || hero.HasBuffOfType(BuffType.SpellImmunity)


### PR DESCRIPTION
GetActualHealth returns really large and strange values, which causes E to never be cast.
This fix comes from iKalista where it is used as killsteal